### PR TITLE
Added path slug strategy for attribute landingpages

### DIFF
--- a/app/code/local/Emico/AttributeLanding/Controller/Router.php
+++ b/app/code/local/Emico/AttributeLanding/Controller/Router.php
@@ -32,6 +32,8 @@ class Emico_AttributeLanding_Controller_Router extends Mage_Core_Controller_Vari
             ->setActionName('index')
             ->setParam('page', $page);
 
+        $request->setAlias(Mage_Core_Model_Url_Rewrite::REWRITE_REQUEST_PATH_ALIAS, $page->getUrlPath());
+
         return true;
     }
 }

--- a/app/code/local/Emico/AttributeLanding/Helper/Data.php
+++ b/app/code/local/Emico/AttributeLanding/Helper/Data.php
@@ -8,18 +8,20 @@ class Emico_AttributeLanding_Helper_Data extends Mage_Core_Helper_Abstract
     /**
      * @return Emico_Tweakwise_Model_UrlBuilder_Strategy_PathStrategy
      */
-    public function getPathSlugStrategy()
+    public function getPathSlugStrategy(): ?Emico_Tweakwise_Model_UrlBuilder_Strategy_StrategyInterface
     {
         $twUriStrategyHelper = Mage::helper('emico_tweakwise/uriStrategy');
+        /** @noinspection NullPointerExceptionInspection */
         return $twUriStrategyHelper->getStrategy('path');
     }
 
     /**
      * @return Emico_Tweakwise_Model_UrlBuilder_Strategy_QueryParamStrategy
      */
-    public function getQueryParamStrategy(): Emico_Tweakwise_Model_UrlBuilder_Strategy_QueryParamStrategy
+    public function getQueryParamStrategy(): ?Emico_Tweakwise_Model_UrlBuilder_Strategy_QueryParamStrategy
     {
         $twUriStrategyHelper = Mage::helper('emico_tweakwise/uriStrategy');
+        /** @noinspection NullPointerExceptionInspection */
         return $twUriStrategyHelper->getStrategy('queryParam');
     }
 }

--- a/app/code/local/Emico/AttributeLanding/Helper/Data.php
+++ b/app/code/local/Emico/AttributeLanding/Helper/Data.php
@@ -3,6 +3,23 @@
  * @author Bram Gerritsen <bgerritsen@emico.nl>
  * @copyright (c) Emico B.V. 2017
  */ 
-class Emico_AttributeLanding_Helper_Data extends Mage_Core_Helper_Abstract {
+class Emico_AttributeLanding_Helper_Data extends Mage_Core_Helper_Abstract
+{
+    /**
+     * @return Emico_Tweakwise_Model_UrlBuilder_Strategy_PathStrategy
+     */
+    public function getPathSlugStrategy()
+    {
+        $twUriStrategyHelper = Mage::helper('emico_tweakwise/uriStrategy');
+        return $twUriStrategyHelper->getStrategy('path');
+    }
 
+    /**
+     * @return Emico_Tweakwise_Model_UrlBuilder_Strategy_QueryParamStrategy
+     */
+    public function getQueryParamStrategy(): Emico_Tweakwise_Model_UrlBuilder_Strategy_QueryParamStrategy
+    {
+        $twUriStrategyHelper = Mage::helper('emico_tweakwise/uriStrategy');
+        return $twUriStrategyHelper->getStrategy('queryParam');
+    }
 }

--- a/app/code/local/Emico/AttributeLanding/Model/Observer.php
+++ b/app/code/local/Emico/AttributeLanding/Model/Observer.php
@@ -69,24 +69,6 @@ class Emico_AttributeLanding_Model_Observer
 
     /**
      * @param Varien_Event_Observer $event
-     */
-    public function tweakwiseUrlbuilderStrategyRegistered(Varien_Event_Observer $event)
-    {
-        $strategy = $event->getData('strategy');
-        if (!$strategy instanceof Emico_Tweakwise_Model_UrlBuilder_Strategy_PathStrategy) {
-            return;
-        }
-
-        $page = Mage::app()->getRequest()->getParam('page');
-        if (!$page instanceof Emico_AttributeLanding_Model_Page) {
-            return;
-        }
-
-        $strategy->setIsAllowedInCurrentContext(false);
-    }
-
-    /**
-     * @param Varien_Event_Observer $event
      * @throws Varien_Exception
      */
     public function addHeadMetaData(Varien_Event_Observer $event)

--- a/app/code/local/Emico/AttributeLanding/Model/Observer/LandingsPageStrategyResolver.php
+++ b/app/code/local/Emico/AttributeLanding/Model/Observer/LandingsPageStrategyResolver.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @author : Edwin Jacobs, email: ejacobs@emico.nl.
+ * @copyright : Copyright Emico B.V. 2020.
+ */
+
+/**
+ * Class Emico_AttributeLanding_Model_Observer_LandingsPageStrategyResolver
+ */
+class Emico_AttributeLanding_Model_Observer_LandingsPageStrategyResolver
+{
+    /**
+     * Sadly there is no hook in strategy registration to skip registration hence the artificial solution
+     * @see Emico_Tweakwise_Helper_UriStrategy::getActiveStrategies()
+     *
+     * @param Varien_Event_Observer $observer
+     */
+    public function disableIncorrectAttributeLandingStrategy(Varien_Event_Observer $observer)
+    {
+        /** @var Emico_Tweakwise_Model_UrlBuilder_Strategy_StrategyInterface $strategy */
+        $strategy = $observer->getData('strategy');
+        // If tweakwise has query param strategy then disable the attributelanding path slug strategy
+        $tweakwiseStrategy = $this->getConfiguredTweakwiseStrategy();
+        if ($tweakwiseStrategy === 'queryParam'
+            && $strategy instanceof Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AttributeLandingPathSlugStrategy
+        ) {
+            $strategy->setStrategyAllowed(false);
+        }
+
+        // If tweakwise has path strategy then disable the AttributeLandingStrategy (this works only for query params)
+        if ($tweakwiseStrategy === 'path'
+            && $strategy instanceof Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AttributeLandingStrategy
+        ) {
+            $strategy->setStrategyAllowed(false);
+        }
+
+        $routeName = Mage::app()->getRequest()->getRouteName();
+        if ($tweakwiseStrategy === 'path'
+            && $strategy instanceof Emico_Tweakwise_Model_UrlBuilder_Strategy_PathStrategy
+            && $routeName !== 'catalogsearch'
+        ) {
+            $strategy->setIsAllowedInCurrentContext(true);
+        }
+    }
+
+    /**
+     * @return Emico_Tweakwise_Model_UrlBuilder_Strategy_StrategyInterface
+     */
+    protected function getConfiguredTweakwiseStrategy()
+    {
+        return Mage::getStoreConfig('emico_tweakwise/navigation/uri_strategy');
+    }
+}

--- a/app/code/local/Emico/AttributeLanding/Model/Page.php
+++ b/app/code/local/Emico/AttributeLanding/Model/Page.php
@@ -139,7 +139,7 @@ class Emico_AttributeLanding_Model_Page extends Mage_Core_Model_Abstract
             return $canonicalUrl;
         }
 
-        return Mage::getBaseUrl() . $this->getUrlPath();
+        return rtrim(Mage::getBaseUrl(), '/') . $this->getUrlPath();
     }
 
     /**

--- a/app/code/local/Emico/AttributeLanding/Model/Tweakwise/UrlStrategy/AbstractAttributeLandingStrategy.php
+++ b/app/code/local/Emico/AttributeLanding/Model/Tweakwise/UrlStrategy/AbstractAttributeLandingStrategy.php
@@ -1,0 +1,194 @@
+<?php
+
+/**
+ * @author : Edwin Jacobs, email: ejacobs@emico.nl.
+ * @copyright : Copyright Emico B.V. 2020.
+ */
+
+
+abstract class Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AbstractAttributeLandingStrategy
+    implements Emico_Tweakwise_Model_UrlBuilder_Strategy_StrategyInterface
+{
+    /**
+     * @var array
+     */
+    protected $pageLookupTable;
+
+    /**
+     * @var bool
+     */
+    protected $strategyAllowed = true;
+
+    /**
+     * @param bool $allowed
+     */
+    public function setStrategyAllowed(bool $allowed)
+    {
+        $this->strategyAllowed = $allowed;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isStrategyAllowed()
+    {
+        return $this->strategyAllowed;
+    }
+
+    /**
+     * @param Emico_Tweakwise_Model_Catalog_Layer $state
+     * @param Emico_Tweakwise_Model_Bus_Type_Facet $facet
+     * @param Emico_Tweakwise_Model_Bus_Type_Attribute $attribute
+     * @param bool $excludeCurrentAttribute
+     * @return array
+     * @throws Exception
+     */
+    protected function getActiveFilters(
+        Emico_Tweakwise_Model_Catalog_Layer $state,
+        Emico_Tweakwise_Model_Bus_Type_Facet $facet,
+        Emico_Tweakwise_Model_Bus_Type_Attribute $attribute,
+        $excludeCurrentAttribute = false
+    ): array {
+        $filters = [];
+
+        $slugMapper = $this->getSlugAttributeMapper();
+        foreach ($state->getSelectedFacets() as $activeFacet) {
+            foreach ($activeFacet->getActiveAttributes() as $activeAttribute) {
+                if ($excludeCurrentAttribute && $activeAttribute === $attribute) {
+                    continue;
+                }
+                $filters[$activeFacet->getFacetSettings()->getUrlKey()][] = $slugMapper->getSlugForAttributeValue($activeAttribute->getTitle());
+            }
+        }
+
+        $facetCode = $facet->getFacetSettings()->getUrlKey();
+        $facetValue = $slugMapper->getSlugForAttributeValue($attribute->getTitle());
+        if (!isset($filters[$facetCode])) {
+            $filters[$facetCode] = [];
+        }
+
+        if (!$excludeCurrentAttribute && !in_array($facetValue, $filters[$facetCode], true)) {
+            $filters[$facetCode][] = $facetValue;
+        }
+
+        return $filters;
+    }
+
+    /**
+     * @param string $filterHash
+     * @return Emico_AttributeLanding_Model_Page|null
+     */
+    protected function findLandingPageByFilters(Mage_Catalog_Model_Category $category, string $filterHash)
+    {
+        if ($this->pageLookupTable === null) {
+            $this->loadPageLookupTable($category);
+        }
+
+        if (isset($this->pageLookupTable[$filterHash])) {
+            return $this->pageLookupTable[$filterHash];
+        }
+
+        return null;
+    }
+
+    /**
+     * Load lookup table
+     * @todo caching
+     */
+    protected function loadPageLookupTable(Mage_Catalog_Model_Category $category)
+    {
+        /** @var Emico_AttributeLanding_Model_Resource_Page_Collection $pageCollection */
+        $pageCollection = Mage::getModel('emico_attributelanding/page')->getCollection();
+        $pageCollection
+            ->addCurrentStoreFilter()
+            ->addFieldToFilter('active', 1)
+            ->addFieldToFilter('category_id', $category->getId());
+
+        /** @var Emico_AttributeLanding_Model_Page $page */
+        foreach ($pageCollection as $page) {
+            $filterHash = $this->buildFilterHash($page->getSearchAttributesKvp(), $page->getCategoryId());
+            $this->pageLookupTable[$filterHash] = $page;
+        }
+    }
+
+    /**
+     * @param array $filters
+     * @param int $categoryId
+     * @return string
+     */
+    protected function buildFilterHash(array $filters, int $categoryId = null)
+    {
+        unset($filters['categorie']);
+        if (empty($filters)) {
+            return null;
+        }
+
+        foreach ($filters as $key => $filterValues) {
+            $sanitizedFilters = array_map('strtolower', $filterValues);
+            $filters[$key] = $sanitizedFilters;
+        }
+
+        if ($categoryId !== null) {
+            $filters['category'] = $categoryId;
+        }
+
+        ksort($filters);
+        return md5(json_encode($filters));
+    }
+
+    /**
+     * @param Zend_Controller_Request_Http $request
+     * @return Emico_Tweakwise_Model_Bus_Request_Navigation
+     */
+    public function decorateTweakwiseRequest(Zend_Controller_Request_Http $httpRequest, Emico_Tweakwise_Model_Bus_Request_Navigation $tweakwiseRequest)
+    {
+        if (!$this->strategyAllowed) {
+            return $tweakwiseRequest;
+        }
+        $page = $httpRequest->get('page');
+        if (!$page instanceof Emico_AttributeLanding_Model_Page) {
+            return $tweakwiseRequest;
+        }
+        foreach ($page->getSearchAttributesKvp() as $key => $values) {
+            foreach ($values as $value) {
+                $tweakwiseRequest->addFacetKey($key, $this->getTweakwiseAttributeValue($key, $value));
+            }
+        }
+        return $tweakwiseRequest;
+    }
+
+    /**
+     * Filter value configured for attribute landing page can be the raw attribute value or the slug. Accommodate for both cases
+     *
+     * @param string $value
+     * @return int|null|string
+     */
+    protected function getTweakwiseAttributeValue(string $key, string $value)
+    {
+        try {
+            return $this->getSlugAttributeMapper()->getAttributeValueBySlug($key, $value);
+        } catch (Emico_TweakwiseExport_Model_Exception_SlugMappingException $exception) {
+            return $value;
+        }
+    }
+
+    /**
+     * @return Emico_TweakwiseExport_Model_SlugAttributeMapping
+     */
+    protected function getSlugAttributeMapper()
+    {
+        return Mage::getSingleton('emico_tweakwiseexport/slugAttributeMapping');
+    }
+
+    /**
+     * @param Emico_Tweakwise_Model_Catalog_Layer $state
+     * @return mixed|void
+     */
+    public function buildCanonicalUrl(Emico_Tweakwise_Model_Catalog_Layer $state)
+    {
+        if (!$this->strategyAllowed) {
+            return null;
+        }
+        return $this->buildUrl($state);
+    }
+}

--- a/app/code/local/Emico/AttributeLanding/Model/Tweakwise/UrlStrategy/AttributeLandingPathSlugStrategy.php
+++ b/app/code/local/Emico/AttributeLanding/Model/Tweakwise/UrlStrategy/AttributeLandingPathSlugStrategy.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * @author Bram Gerritsen <bgerritsen@emico.nl>
+ * @copyright (c) Emico B.V. 2017
+ */
+class Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AttributeLandingPathSlugStrategy
+    extends Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AbstractAttributeLandingStrategy
+    implements Emico_Tweakwise_Model_UrlBuilder_Strategy_RoutingStrategyInterface
+{
+    /**
+     * @var
+     */
+    protected $_pathStrategyBaseUrl;
+
+    /**
+     * @inheritDoc
+     */
+    public function matchUrl(Zend_Controller_Request_Http $request)
+    {
+        if (!$this->strategyAllowed) {
+            return null;
+        }
+        $path = trim($request->getPathInfo(), '/');
+        $possiblePaths = [];
+        foreach (explode('/', $path) as $index => $pathPart) {
+            if (empty($possiblePaths)) {
+                $possiblePaths[] = $pathPart;
+                continue;
+            }
+            $possiblePaths[$index] = $possiblePaths[$index - 1] . '/' . $pathPart;
+        }
+
+        $possiblePages = Mage::getResourceModel('emico_attributelanding/page_collection')
+            ->addFieldToFilter('url_path', ['in' => $possiblePaths]);
+        if (!$pages = $possiblePages->getItems()) {
+            return false;
+        }
+        foreach ($pages as $page) {
+            $page->getResource()->afterLoad($page);
+        }
+
+        $pages = array_filter(
+            $pages,
+            static function (Emico_AttributeLanding_Model_Page $page) {
+                return $page->isAllowedForStore();
+            }
+        );
+
+        if (empty($pages)) {
+            return false;
+        }
+
+        usort(
+            $pages,
+            static function (Emico_AttributeLanding_Model_Page $pageA, Emico_AttributeLanding_Model_Page $pageB) {
+                return strlen($pageA->getUrlPath()) - strlen($pageB->getUrlPath());
+            }
+        );
+        /** @var Emico_AttributeLanding_Model_Page $page */
+        $page = reset($pages);
+
+        $request
+            ->setModuleName('attributelanding')
+            ->setControllerName('index')
+            ->setActionName('index')
+            ->setParam('page', $page);
+
+        $request->setAlias(Mage_Core_Model_Url_Rewrite::REWRITE_REQUEST_PATH_ALIAS, $path);
+        $request->setParam('filter_path', substr($path, strlen($page->getUrlPath())));
+
+        return true;
+    }
+
+    /**
+     * Builds the URL for a facet attribute
+     *
+     * @param Emico_Tweakwise_Model_Catalog_Layer $state
+     * @param Emico_Tweakwise_Model_Bus_Type_Facet|null $facet
+     * @param Emico_Tweakwise_Model_Bus_Type_Attribute $attribute
+     * @return null|string
+     * @throws Exception
+     */
+    public function buildUrl(Emico_Tweakwise_Model_Catalog_Layer $state, Emico_Tweakwise_Model_Bus_Type_Facet $facet = null, Emico_Tweakwise_Model_Bus_Type_Attribute $attribute = null)
+    {
+        if (!$this->strategyAllowed) {
+            return null;
+        }
+        if ($facet === null || $attribute === null || $facet->isCategory()) {
+            return null;
+        }
+
+        $category = Mage::registry('current_category');
+        if (!$category instanceof Mage_Catalog_Model_Category) {
+            return null;
+        }
+
+        /** @var Emico_AttributeLanding_Model_Page $landingPage */
+        $landingPage = Mage::app()->getRequest()->getParam('page');
+
+        $twUrlStrategy = Mage::helper('emico_attributelanding')->getPathSlugStrategy();
+        $twUrlResult = $twUrlStrategy->buildUrl($state, $facet, $attribute);
+
+        if ($landingPage && $attribute->getIsSelected() && $this->isFilterPartOfLandingPage($facet, $attribute, $landingPage)) {
+            // This will construct the clear filter url
+            return $twUrlResult . '#no-ajax';
+        }
+
+        // Check if we have an attribute landing page available for the filter combination
+        $filters = $this->getActiveFilters($state, $facet, $attribute);
+        $filterHash = $this->buildFilterHash($filters, $category->getId());
+        $targetLandingPage = $filterHash ? $this->findLandingPageByFilters($category, $filterHash) : null;
+
+        if ($targetLandingPage) {
+            return '/' . $targetLandingPage->getUrlPath() . '#no-ajax';
+        }
+
+        // No matches
+        if (!$landingPage) {
+            return null;
+        }
+
+        $strippedTwUrlResult = str_replace([$this->getPathStrategyBaseUrl($category), $category->getUrlPath()], '', $twUrlResult);
+        foreach ($landingPage->getSearchAttributesKvp() as $filter => $filterValues) {
+            foreach ($filterValues as $filterValue) {
+                $strippedTwUrlResult = str_replace(strtolower("/$filter/$filterValue"), '', $strippedTwUrlResult);
+            }
+        }
+
+        return "{$landingPage->getUrlPath()}$strippedTwUrlResult";
+    }
+
+    /**
+     * @param Emico_Tweakwise_Model_Bus_Type_Facet $facet
+     * @param Emico_Tweakwise_Model_Bus_Type_Attribute $attribute
+     * @param Emico_AttributeLanding_Model_Page $landingPage
+     * @return bool
+     */
+    protected function isFilterPartOfLandingPage(
+        Emico_Tweakwise_Model_Bus_Type_Facet $facet,
+        Emico_Tweakwise_Model_Bus_Type_Attribute $attribute,
+        Emico_AttributeLanding_Model_Page $landingPage
+    ) {
+        $pageFilterDefinition = $landingPage->getSearchAttributesKvp();
+        if (!isset($pageFilterDefinition[$facet->getFacetSettings()->getUrlKey()])) {
+            return false;
+        }
+
+        $filterValue = $pageFilterDefinition[$facet->getFacetSettings()->getUrlKey()];
+        return in_array($attribute->getTitle(), $filterValue,true);
+    }
+
+    /**
+     * This is a duplicate from tweakwise path strategy since it is protected
+     *
+     * @return string
+     * @throws Mage_Core_Model_Store_Exception
+     */
+    protected function getPathStrategyBaseUrl(Mage_Catalog_Model_Category $category)
+    {
+        if ($this->_pathStrategyBaseUrl === null) {
+            $categoryUrl = $category->getUrl();
+            $queryPosition = strpos($categoryUrl, '?');
+            $this->_pathStrategyBaseUrl = ($queryPosition > 0) ? substr($categoryUrl, 0, $queryPosition) : $categoryUrl;
+        }
+
+        return rtrim($this->_pathStrategyBaseUrl, '/');
+    }
+}

--- a/app/code/local/Emico/AttributeLanding/Model/Tweakwise/UrlStrategy/AttributeLandingPathSlugStrategy.php
+++ b/app/code/local/Emico/AttributeLanding/Model/Tweakwise/UrlStrategy/AttributeLandingPathSlugStrategy.php
@@ -9,9 +9,9 @@ class Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AttributeLandingPathSlu
     implements Emico_Tweakwise_Model_UrlBuilder_Strategy_RoutingStrategyInterface
 {
     /**
-     * @var
+     * @var string
      */
-    protected $_pathStrategyBaseUrl;
+    protected $pathStrategyBaseUrl;
 
     /**
      * @inheritDoc
@@ -99,6 +99,9 @@ class Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AttributeLandingPathSlu
         $landingPage = Mage::app()->getRequest()->getParam('page');
 
         $twUrlStrategy = Mage::helper('emico_attributelanding')->getPathSlugStrategy();
+        if (!$twUrlStrategy) {
+            return null;
+        }
         $twUrlResult = $twUrlStrategy->buildUrl($state, $facet, $attribute);
 
         if ($landingPage && $attribute->getIsSelected() && $this->isFilterPartOfLandingPage($facet, $attribute, $landingPage)) {
@@ -112,7 +115,7 @@ class Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AttributeLandingPathSlu
         $targetLandingPage = $filterHash ? $this->findLandingPageByFilters($category, $filterHash) : null;
 
         if ($targetLandingPage) {
-            return '/' . $targetLandingPage->getUrlPath() . '#no-ajax';
+            return $targetLandingPage->getUrlPath() . '#no-ajax';
         }
 
         // No matches
@@ -120,7 +123,11 @@ class Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AttributeLandingPathSlu
             return null;
         }
 
-        $strippedTwUrlResult = str_replace([$this->getPathStrategyBaseUrl($category), $category->getUrlPath()], '', $twUrlResult);
+        $strippedTwUrlResult = str_replace(
+            [$this->getPathStrategyBaseUrl($category), $category->getUrlPath()],
+            '',
+            $twUrlResult
+        );
         foreach ($landingPage->getSearchAttributesKvp() as $filter => $filterValues) {
             foreach ($filterValues as $filterValue) {
                 $strippedTwUrlResult = str_replace(strtolower("/$filter/$filterValue"), '', $strippedTwUrlResult);
@@ -147,7 +154,7 @@ class Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AttributeLandingPathSlu
         }
 
         $filterValue = $pageFilterDefinition[$facet->getFacetSettings()->getUrlKey()];
-        return in_array($attribute->getTitle(), $filterValue,true);
+        return in_array($attribute->getTitle(), $filterValue, true);
     }
 
     /**
@@ -158,12 +165,12 @@ class Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AttributeLandingPathSlu
      */
     protected function getPathStrategyBaseUrl(Mage_Catalog_Model_Category $category)
     {
-        if ($this->_pathStrategyBaseUrl === null) {
+        if ($this->pathStrategyBaseUrl === null) {
             $categoryUrl = $category->getUrl();
             $queryPosition = strpos($categoryUrl, '?');
-            $this->_pathStrategyBaseUrl = ($queryPosition > 0) ? substr($categoryUrl, 0, $queryPosition) : $categoryUrl;
+            $this->pathStrategyBaseUrl = ($queryPosition > 0) ? substr($categoryUrl, 0, $queryPosition) : $categoryUrl;
         }
 
-        return rtrim($this->_pathStrategyBaseUrl, '/');
+        return rtrim($this->pathStrategyBaseUrl, '/');
     }
 }

--- a/app/code/local/Emico/AttributeLanding/Model/Tweakwise/UrlStrategy/AttributeLandingStrategy.php
+++ b/app/code/local/Emico/AttributeLanding/Model/Tweakwise/UrlStrategy/AttributeLandingStrategy.php
@@ -4,22 +4,25 @@
  * @author Bram Gerritsen <bgerritsen@emico.nl>
  * @copyright (c) Emico B.V. 2017
  */
-class Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AttributeLandingStrategy implements Emico_Tweakwise_Model_UrlBuilder_Strategy_StrategyInterface
+class Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AttributeLandingStrategy extends Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AbstractAttributeLandingStrategy
 {
-    /**
-     * @var array
-     */
-    private $pageLookupTable;
-
     /**
      * Builds the URL for a facet attribute
      *
      * @param Emico_Tweakwise_Model_Catalog_Layer $state
+     * @param Emico_Tweakwise_Model_Bus_Type_Facet|null $facet
      * @param Emico_Tweakwise_Model_Bus_Type_Attribute $attribute
      * @return null|string
+     * @throws Exception
      */
-    public function buildUrl(Emico_Tweakwise_Model_Catalog_Layer $state, Emico_Tweakwise_Model_Bus_Type_Facet $facet = null, Emico_Tweakwise_Model_Bus_Type_Attribute $attribute = null)
-    {
+    public function buildUrl(
+        Emico_Tweakwise_Model_Catalog_Layer $state,
+        Emico_Tweakwise_Model_Bus_Type_Facet $facet = null,
+        Emico_Tweakwise_Model_Bus_Type_Attribute $attribute = null
+    ) {
+        if (!$this->strategyAllowed) {
+            return null;
+        }
         if ($facet === null || $attribute === null || $facet->isCategory()) {
             return null;
         }
@@ -33,12 +36,8 @@ class Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AttributeLandingStrateg
         /** @var Emico_AttributeLanding_Model_Page $landingPage */
         $landingPage = Mage::app()->getRequest()->getParam('page');
         if ($landingPage && $attribute->getIsSelected()) {
-            $filterPart = http_build_query($this->getQueryParamStrategy()->getUrlKeyValPairs($facet, $attribute));
-            $removeUrl = $landingPage->getUrlPath();
-            if (!empty($filterPart)) {
-                $removeUrl .= '?' . $filterPart;
-            }
-            return $removeUrl;
+            $queryParamStrategy = Mage::helper('emico_attributelanding')->getQueryParamStrategy();
+            return $landingPage->getUrlPath() . '?' . http_build_query($queryParamStrategy->getUrlKeyValPairs($facet, $attribute));
         }
 
         // Check if we have an attribute landing page available for the filter combination
@@ -52,189 +51,9 @@ class Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AttributeLandingStrateg
         $page = $this->findLandingPageByFilters($category, $filterHash);
 
         if ($page !== null) {
-            return $page->getUrlPath() . '#no-ajax';
+            return '/' . $page->getUrlPath() . '#no-ajax';
         }
 
         return null;
-    }
-
-    /**
-     * @param Emico_Tweakwise_Model_Catalog_Layer $state
-     * @param Emico_Tweakwise_Model_Bus_Type_Facet $facet
-     * @param Emico_Tweakwise_Model_Bus_Type_Attribute $attribute
-     * @param bool $excludeCurrentAttribute
-     * @return array
-     * @throws Exception
-     */
-    protected function getActiveFilters(
-        Emico_Tweakwise_Model_Catalog_Layer $state,
-        Emico_Tweakwise_Model_Bus_Type_Facet $facet,
-        Emico_Tweakwise_Model_Bus_Type_Attribute $attribute,
-        $excludeCurrentAttribute = false
-    ) {
-        $filters = [];
-
-        $slugMapper = $this->getSlugAttributeMapper();
-        foreach ($state->getSelectedFacets() as $activeFacet) {
-            foreach ($activeFacet->getActiveAttributes() as $activeAttribute) {
-                if ($excludeCurrentAttribute && $activeAttribute === $attribute) {
-                    continue;
-                }
-                $filters[$activeFacet->getFacetSettings()->getUrlKey()][] = $slugMapper->getSlugForAttributeValue($activeAttribute->getTitle());
-            }
-        }
-
-        $facetCode = $facet->getFacetSettings()->getUrlKey();
-        $facetValue = $slugMapper->getSlugForAttributeValue($attribute->getTitle());
-        if (!isset($filters[$facetCode])) {
-            $filters[$facetCode] = [];
-        }
-
-        if (!$excludeCurrentAttribute && !in_array($facetValue, $filters[$facetCode], true)) {
-            $filters[$facetCode][] = $facetValue;
-        }
-
-        return $filters;
-    }
-
-    /**
-     * @param Zend_Controller_Request_Http $request
-     * @return Emico_Tweakwise_Model_Bus_Request_Navigation
-     */
-    public function decorateTweakwiseRequest(Zend_Controller_Request_Http $httpRequest, Emico_Tweakwise_Model_Bus_Request_Navigation $tweakwiseRequest)
-    {
-        $page = $httpRequest->get('page');
-        if (!$page instanceof Emico_AttributeLanding_Model_Page) {
-            return $tweakwiseRequest;
-        }
-        foreach ($page->getSearchAttributesKvp() as $key => $values) {
-            foreach ($values as $value) {
-                $tweakwiseRequest->addFacetKey($key, $this->getTweakwiseAttributeValue($value));
-            }
-        }
-        return $tweakwiseRequest;
-    }
-
-    /**
-     * Filter value configured for attribute landing page can be the raw attribute value or the slug. Accommodate for both cases
-     *
-     * @param string $value
-     * @return int|null|string
-     */
-    protected function getTweakwiseAttributeValue(string $value)
-    {
-        try {
-            return $this->getSlugAttributeMapper()->getAttributeValueBySlug($value);
-        } catch (Emico_TweakwiseExport_Model_Exception_SlugMappingException $exception) {
-            return $value;
-        }
-    }
-
-    /**
-     * @param array $filters
-     * @param int $categoryId
-     * @return string
-     */
-    protected function buildFilterHash(array $filters, int $categoryId = null)
-    {
-        unset($filters['categorie']);
-        if (empty($filters)) {
-            return null;
-        }
-
-        foreach ($filters as $key => $filterValues) {
-            $sanitizedFilters = array_map('strtolower', $filterValues);
-            $filters[$key] = $sanitizedFilters;
-        }
-        
-        if ($categoryId !== null && !$this->isRootCategory($categoryId)) {
-            $filters['category'] = $categoryId;
-        }
-
-        ksort($filters);
-        return md5(json_encode($filters));
-    }
-
-    /**
-     * @param int $categoryId
-     * @return bool
-     */
-    protected function isRootCategory(int $categoryId): bool
-    {
-        try {
-            $rootCategoryId = (int) Mage::app()->getStore()->getRootCategoryId();
-            return $rootCategoryId === $categoryId;
-        } catch (Exception $exception) {
-            return false;
-        }
-    }
-
-    /**
-     * @param string $filterHash
-     * @return Emico_AttributeLanding_Model_Page|null
-     */
-    protected function findLandingPageByFilters(Mage_Catalog_Model_Category $category, string $filterHash)
-    {
-        if ($this->pageLookupTable === null) {
-            $this->loadPageLookupTable($category);
-        }
-
-        if (isset($this->pageLookupTable[$filterHash])) {
-            return $this->pageLookupTable[$filterHash];
-        }
-
-        return null;
-    }
-
-    /**
-     * Load lookup table
-     * @todo caching
-     */
-    protected function loadPageLookupTable(Mage_Catalog_Model_Category $category)
-    {
-        $categoryFilterClause = [
-            ['eq' => $category->getId()]
-        ];
-        if ($this->isRootCategory($category->getId())) {
-            $categoryFilterClause[] = ['null' => true];
-        }
-
-        /** @var Emico_AttributeLanding_Model_Resource_Page_Collection $pageCollection */
-        $pageCollection = Mage::getModel('emico_attributelanding/page')->getCollection();
-        $pageCollection
-            ->addCurrentStoreFilter()
-            ->addFieldToFilter('active', 1)
-            ->addFieldToFilter('category_id', $categoryFilterClause);
-
-        /** @var Emico_AttributeLanding_Model_Page $page */
-        foreach ($pageCollection as $page) {
-            $filterHash = $this->buildFilterHash($page->getSearchAttributesKvp(), $page->getCategoryId());
-            $this->pageLookupTable[$filterHash] = $page;
-        }
-    }
-
-    /**
-     * @return Emico_Tweakwise_Model_UrlBuilder_Strategy_QueryParamStrategy|false|Mage_Core_Model_Abstract
-     */
-    protected function getQueryParamStrategy(): Emico_Tweakwise_Model_UrlBuilder_Strategy_QueryParamStrategy
-    {
-        return Mage::getModel('emico_tweakwise/urlBuilder_strategy_queryParamStrategy');
-    }
-
-    /**
-     * @return Emico_TweakwiseExport_Model_SlugAttributeMapping
-     */
-    protected function getSlugAttributeMapper()
-    {
-        return Mage::getSingleton('emico_tweakwiseexport/slugAttributeMapping');
-    }
-
-    /**
-     * @param Emico_Tweakwise_Model_Catalog_Layer $state
-     * @return mixed|void
-     */
-    public function buildCanonicalUrl(Emico_Tweakwise_Model_Catalog_Layer $state)
-    {
-        return $this->buildUrl($state);
     }
 }

--- a/app/code/local/Emico/AttributeLanding/Model/Tweakwise/UrlStrategy/AttributeLandingStrategy.php
+++ b/app/code/local/Emico/AttributeLanding/Model/Tweakwise/UrlStrategy/AttributeLandingStrategy.php
@@ -37,21 +37,22 @@ class Emico_AttributeLanding_Model_Tweakwise_UrlStrategy_AttributeLandingStrateg
         $landingPage = Mage::app()->getRequest()->getParam('page');
         if ($landingPage && $attribute->getIsSelected()) {
             $queryParamStrategy = Mage::helper('emico_attributelanding')->getQueryParamStrategy();
+            if (!$queryParamStrategy) {
+                return null;
+            }
             return $landingPage->getUrlPath() . '?' . http_build_query($queryParamStrategy->getUrlKeyValPairs($facet, $attribute));
         }
 
         // Check if we have an attribute landing page available for the filter combination
         $filters = $this->getActiveFilters($state, $facet, $attribute);
-
         $filterHash = $this->buildFilterHash($filters, $category->getId());
         if ($filterHash === null) {
             return null;
         }
 
         $page = $this->findLandingPageByFilters($category, $filterHash);
-
         if ($page !== null) {
-            return '/' . $page->getUrlPath() . '#no-ajax';
+            return $page->getUrlPath() . '#no-ajax';
         }
 
         return null;

--- a/app/code/local/Emico/AttributeLanding/controllers/IndexController.php
+++ b/app/code/local/Emico/AttributeLanding/controllers/IndexController.php
@@ -50,7 +50,9 @@ class Emico_AttributeLanding_IndexController extends Mage_Core_Controller_Front_
         $this->initCategory($page);
         $this->setFilterState($page);
 
-        $this->getRequest()->setAlias(Mage_Core_Model_Url_Rewrite::REWRITE_REQUEST_PATH_ALIAS, $page->getUrlPath());
+        if (!$this->getRequest()->getAlias(Mage_Core_Model_Url_Rewrite::REWRITE_REQUEST_PATH_ALIAS)) {
+            $this->getRequest()->setAlias(Mage_Core_Model_Url_Rewrite::REWRITE_REQUEST_PATH_ALIAS, $page->getUrlPath());
+        }
 
         if (Mage::helper('core')->isModuleEnabled('Emico_Tweakwise') && $templateId = $page->getData('tweakwise_template')) {
             Mage::getSingleton('emico_tweakwise/catalog_layer')->setTemplateId($templateId);

--- a/app/code/local/Emico/AttributeLanding/etc/config.xml
+++ b/app/code/local/Emico/AttributeLanding/etc/config.xml
@@ -42,6 +42,14 @@
             </emico_attributelanding_setup>
         </resources>
         <events>
+            <tweakwise_urlbuilder_strategy_registered>
+                <observers>
+                    <emico_attributelanding_tweakwise_strategy_registration>
+                        <class>emico_attributelanding/observer_landingsPageStrategyResolver</class>
+                        <method>disableIncorrectAttributeLandingStrategy</method>
+                    </emico_attributelanding_tweakwise_strategy_registration>
+                </observers>
+            </tweakwise_urlbuilder_strategy_registered>
             <sitemap_categories_generating_before>
                 <observers>
                     <emico_attributelanding_sitemap>
@@ -50,14 +58,6 @@
                     </emico_attributelanding_sitemap>
                 </observers>
             </sitemap_categories_generating_before>
-            <tweakwise_urlbuilder_strategy_registered>
-                <observers>
-                    <emico_attributelanding>
-                        <class>emico_attributelanding/observer</class>
-                        <method>tweakwiseUrlbuilderStrategyRegistered</method>
-                    </emico_attributelanding>
-                </observers>
-            </tweakwise_urlbuilder_strategy_registered>
             <controller_action_layout_render_before_emico_attributelanding_index_index>
                 <observers>
                     <emico_attributelanding_metadata>
@@ -75,6 +75,12 @@
                     <priority>1</priority>
                     <selectable>0</selectable>
                 </attribute_landing>
+                <attribute_landing_path>
+                    <class>emico_attributelanding/tweakwise_urlStrategy_attributeLandingPathSlugStrategy</class>
+                    <active>1</active>
+                    <priority>0</priority>
+                    <selectable>0</selectable>
+                </attribute_landing_path>
             </urlbuilder_strategies>
         </emico_tweakwise>
     </global>


### PR DESCRIPTION
Path slug strategy for landingspages meaning that filter urls will behave as /filterName/filterValue instead of ?filterName=filterValue